### PR TITLE
Fix the cron values when no defaults are set

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,10 +21,10 @@ echo "CRON frequency: " $CRON_FREQUENCY
 # The process running under cron needs to know where the to find the kubernetes api
 env_vars="PATH=$PATH KUBERNETES_PORT=$KUBERNETES_PORT KUBERNETES_PORT_443_TCP_PORT=$KUBERNETES_PORT_443_TCP_PORT KUBERNETES_SERVICE_PORT=$KUBERNETES_SERVICE_PORT KUBERNETES_SERVICE_HOST=$KUBERNETES_SERVICE_HOST KUBERNETES_PORT_443_TCP_PROTO=$KUBERNETES_PORT_443_TCP_PROTO KUBERNETES_PORT_443_TCP_ADDR=$KUBERNETES_PORT_443_TCP_ADDR KUBERNETES_PORT_443_TCP=$KUBERNETES_PORT_443_TCP"
 
-refresh_cron="$CRON_FREQUENCY $env_vars SECRET_NAME=$SECRET_NAME NAMESPACE=$NAMESPACE DEPLOYMENTS='$DEPLOYMENTS' DOMAINS='$DOMAINS' EMAIL=$EMAIL /bin/bash /letsencrypt/refresh_certs.sh >> /var/log/cron-encrypt.log 2>&1"
+refresh_cron="$CRON_REFRESH_FREQUENCY $env_vars SECRET_NAME=$SECRET_NAME NAMESPACE=$NAMESPACE DEPLOYMENTS='$DEPLOYMENTS' DOMAINS='$DOMAINS' EMAIL=$EMAIL /bin/bash /letsencrypt/refresh_certs.sh >> /var/log/cron-encrypt.log 2>&1"
 (crontab -u root -l; echo "$refresh_cron" ) | crontab -u root -
 
-new_cert_cron="$CRON_FREQUENCY $env_vars SECRET_NAME=$SECRET_NAME NAMESPACE=$NAMESPACE DEPLOYMENTS='$DEPLOYMENTS' DOMAINS='$DOMAINS' EMAIL=$EMAIL /bin/bash /letsencrypt/check_new_certs.sh >> /var/log/cron-encrypt.log 2>&1"
+new_cert_cron="$CRON_NEW_CHECK_FREQUENCY $env_vars SECRET_NAME=$SECRET_NAME NAMESPACE=$NAMESPACE DEPLOYMENTS='$DEPLOYMENTS' DOMAINS='$DOMAINS' EMAIL=$EMAIL /bin/bash /letsencrypt/check_new_certs.sh >> /var/log/cron-encrypt.log 2>&1"
 (crontab -u root -l; echo "$new_cert_cron" ) | crontab -u root -
 
 if [ -n "${LETSENCRYPT_ENDPOINT+1}" ]; then


### PR DESCRIPTION
The shell variables for the refresh and new check cron schedules were
initialized but not being used. This caused the schedule to default to
an empty string.